### PR TITLE
Substitute "kAllowlistedExtensionId" for "kWhitelisted"

### DIFF
--- a/mv2-archive/api/webview/comm_demo_app/app.js
+++ b/mv2-archive/api/webview/comm_demo_app/app.js
@@ -4,8 +4,8 @@
 
 'use strict;'
 
-const kWhitelistedExtensionId = 'dpicdiinminmigempanoghnpckmkfepi';
-const kExtensionIds = [kWhitelistedExtensionId];
+const kAllowlistedExtensionId = 'dpicdiinminmigempanoghnpckmkfepi';
+const kExtensionIds = [kAllowlistedExtensionId];
 
 let portMap = {};
 let webview = null;
@@ -130,7 +130,7 @@ function connectToExtension(extensionId) {
 }
 
 function setUpExtensionHandlers() {
-  let port = portMap[kWhitelistedExtensionId];
+  let port = portMap[kAllowlistedExtensionId];
   // Some examples of UI in the app requesting services from the guest.
   // The replies from the extension are injected into the guest and executed
   // via the port.onMessage handler declared above.


### PR DESCRIPTION
Issue 842296: Use inclusive terminology throughout Chromium https://bugs.chromium.org/p/chromium/issues/detail?id=842296

Chromium's source code uses "blacklist" and "whitelist" a lot. Ideally we wouldn't do that since it unnecessarily reinforces the notion that black==bad and white==good. https://mcwriting11.blogspot.com/2014/06/that-word-black-by-langston-hughes.html illustrates this problem in a lighthearted, if somewhat pointed way.